### PR TITLE
changed workflow logic to git tags

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,8 +1,8 @@
 on:
   push:
-    branches:
-      - main
-  workflow_dispatch:
+    tags:
+      - "v*.*.*"
+
 jobs:
   release:
     permissions:


### PR DESCRIPTION
changed workflow logic to git tags

After pushing to main, publish a new chart version like this:

git tag v0.2.0
git push origin v0.2.0