### PR TITLE
changed default values to a 1 node cluster for testing purposes

### DIFF
--- a/helm-charts/minio-distributed/values.yaml
+++ b/helm-charts/minio-distributed/values.yaml
@@ -1,11 +1,11 @@
-replicaCount: 4
+replicaCount: 1
 
 minio:
-  image: minio/minio:RELEASE.2024-05-01T00-00-00Z
+  image: minio/minio:latest-cicd
   accessKey: "minioadmin"
   secretKey: "minioadmin"
-  drivesPerNode: 4
-  storageRequest: 10Gi
+  drivesPerNode: 1
+  storageRequest: 2Gi
 
 service:
   type: ClusterIP


### PR DESCRIPTION
What does this change?

changed default values to a 1 node cluster for testing purposes and changed the default tag for minio docker image to latest-cicd