### PR TITLE
explicitely adding /usr/bin for curl command 

### DIFF
--- a/helm-charts/minio-distributed/templates/job-init.yaml
+++ b/helm-charts/minio-distributed/templates/job-init.yaml
@@ -24,7 +24,7 @@ spec:
             echo "Creating bucket {{ .Values.initJob.bucket }}..."
             mc mb --ignore-existing myminio/{{ .Values.initJob.bucket }}
             echo "Downloading file..."
-            curl -L -o /tmp/{{ .Values.initJob.fileName }} {{ .Values.initJob.fileUrl }}
+            /usr/bin/curl -L -o /tmp/{{ .Values.initJob.fileName }} {{ .Values.initJob.fileUrl }}
             echo "Uploading to bucket..."
             mc cp /tmp/{{ .Values.initJob.fileName }} myminio/{{ .Values.initJob.bucketName }}/
             


### PR DESCRIPTION
 explicitely adding /usr/bin for curl command  PATH is somehow ignored in Init Job