### PR TITLE
chore: changed image to bitnami, because of issues with curl and wget…

### DIFF
--- a/helm-charts/minio-distributed/templates/job-init.yaml
+++ b/helm-charts/minio-distributed/templates/job-init.yaml
@@ -10,7 +10,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: minio-init
-        image: minio/mc:latest
+        image: bitnami/minio:latest
         command:
           - /bin/sh
           - -c


### PR DESCRIPTION
chore: changed image to bitnami, because of issues with curl and wget in standard minio image